### PR TITLE
Synonym Primary Keys

### DIFF
--- a/src/main/java/gov/nih/nci/bento_ri/model/PrivateESDataFetcher.java
+++ b/src/main/java/gov/nih/nci/bento_ri/model/PrivateESDataFetcher.java
@@ -615,6 +615,10 @@ public class PrivateESDataFetcher extends AbstractPrivateESDataFetcher {
                 Map.entry("osName", "synonyms"),
                 Map.entry("nested", List.of(
                     Map.ofEntries(
+                        Map.entry("gqlName", "id"),
+                        Map.entry("osName", "id")
+                    ),
+                    Map.ofEntries(
                         Map.entry("gqlName", "associated_id"),
                         Map.entry("osName", "associated_id")
                     ),
@@ -678,6 +682,11 @@ public class PrivateESDataFetcher extends AbstractPrivateESDataFetcher {
             )),
 
             // CPI Data
+            Map.entry("synonyms.id", Map.ofEntries(
+                Map.entry("osName", "id"),
+                Map.entry("isNested", true),
+                Map.entry("path", "synonyms")
+            )),
             Map.entry("synonyms.associated_id", Map.ofEntries(
                 Map.entry("osName", "associated_id"),
                 Map.entry("isNested", true),

--- a/src/main/resources/graphql/ccdi-portal-private-es.graphql
+++ b/src/main/resources/graphql/ccdi-portal-private-es.graphql
@@ -46,7 +46,7 @@ type CohortMetadataReturnObject {
     # CPI Data
     diagnoses: [DiagnosisOverviewResult]
     survivals: [SurvivalOverviewResult]
-    synonyms: [CpiDataReturnObject]
+    synonyms: [NestedSynonym]
     treatments: [TreatmentOverviewResult]
     treatment_responses: [TreatmentResponseOverviewResult]
 }
@@ -55,6 +55,15 @@ type CpiDataReturnObject {
     associated_id: String
     data_location: String
     data_type: String
+    domain_category: String
+    domain_description: String
+    repository_of_synonym_id: String
+}
+
+type NestedSynonym {
+    id: String
+    associated_id: String
+    data_location: String
     domain_category: String
     domain_description: String
     repository_of_synonym_id: String


### PR DESCRIPTION
[C3DC-1614](https://tracker.nci.nih.gov/browse/C3DC-1614) specifies the `id` property for Synonym objects in the JSON. This PR includes the `id` property among the return fields for the cohort metadata response.