### PR TITLE
C3DC-1658 (V2) added missing 'to' field

### DIFF
--- a/src/main/java/gov/nih/nci/bento_ri/model/PrivateESDataFetcher.java
+++ b/src/main/java/gov/nih/nci/bento_ri/model/PrivateESDataFetcher.java
@@ -305,7 +305,8 @@ public class PrivateESDataFetcher extends AbstractPrivateESDataFetcher {
             ),
             Map.of(
                 "key", "> 29",
-                "from", 30 * 365
+                "from", 30 * 365,
+                "to", Integer.MAX_VALUE
             )
         );
         numRanges = ranges.size();


### PR DESCRIPTION
[C3DC-1658](https://tracker.nci.nih.gov/browse/C3DC-1658)

we were missing a 'To' field. The ranges object is used as a default fallback value but we did not define it since there is no cap.

This however caused the query to return all valid records, ignoring the range since it did not have two numbers to create a range.