### PR TITLE
Vulnerability fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG TEMURIN_SHA256_ARM64="REPLACE_WITH_OFFICIAL_SHA256_FOR_OpenJDK21U-jdk_aarch6
 RUN set -eux; \
     apt-get update; \
     apt-get -y upgrade; \
-    apt-get install -y --no-install-recommends ca-certificates curl tar unzip; \
+    apt-get install -y --no-install-recommends ca-certificates curl tar; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
       amd64) temurin_arch="x64"; temurin_sha256="$TEMURIN_SHA256_AMD64" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG TEMURIN_SHA256_ARM64="357fee29fb0d5c079f6730db98b28942df13a6eed426f6c61cd4ad
 RUN set -eux; \
     apt-get update; \
     apt-get -y upgrade; \
-    apt-get install -y --no-install-recommends ca-certificates curl tar; \
+    apt-get install -y --no-install-recommends ca-certificates curl tar unzip; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
       amd64) temurin_arch="x64"; temurin_sha256="$TEMURIN_SHA256_AMD64" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ FROM tomcat:11.0.18-jdk21 AS fnl_base_image
 ARG TEMURIN_DIR=jdk-21.0.10+7
 ARG TEMURIN_BUILD=21.0.10_7
 # SHA256 checksums for the Temurin JDK tarballs (replace with the official published values)
-ARG TEMURIN_SHA256_AMD64="REPLACE_WITH_OFFICIAL_SHA256_FOR_OpenJDK21U-jdk_x64_linux_hotspot_21.0.10_7.tar.gz"
-ARG TEMURIN_SHA256_ARM64="REPLACE_WITH_OFFICIAL_SHA256_FOR_OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.10_7.tar.gz"
+ARG TEMURIN_SHA256_AMD64="ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4"
+ARG TEMURIN_SHA256_ARM64="357fee29fb0d5c079f6730db98b28942df13a6eed426f6c61cd4ad703ab27b9a"
 RUN set -eux; \
     apt-get update; \
     apt-get -y upgrade; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM tomcat:11.0.18-jdk21 AS fnl_base_image
 # Upgrade OS packages, install deps, and update Java to Temurin 21.0.10.
 ARG TEMURIN_DIR=jdk-21.0.10+7
 ARG TEMURIN_BUILD=21.0.10_7
-# SHA256 checksums for the Temurin JDK tarballs (replace with the official published values)
+# Official SHA256 checksums for the Temurin JDK tarballs for the above TEMURIN_DIR/TEMURIN_BUILD.
 ARG TEMURIN_SHA256_AMD64="ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4"
 ARG TEMURIN_SHA256_ARM64="357fee29fb0d5c079f6730db98b28942df13a6eed426f6c61cd4ad703ab27b9a"
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN mvn package -DskipTests
 FROM tomcat:11.0.18-jdk21 AS fnl_base_image
 
 # Upgrade OS packages, install deps, and update Java to Temurin 21.0.10.
-ARG TEMURIN_DIR="jdk-21.0.10+7"
-ARG TEMURIN_BUILD="21.0.10_7"
+ARG TEMURIN_DIR=jdk-21.0.10+7
+ARG TEMURIN_BUILD=21.0.10_7
 # SHA256 checksums for the Temurin JDK tarballs (replace with the official published values)
 ARG TEMURIN_SHA256_AMD64="REPLACE_WITH_OFFICIAL_SHA256_FOR_OpenJDK21U-jdk_x64_linux_hotspot_21.0.10_7.tar.gz"
 ARG TEMURIN_SHA256_ARM64="REPLACE_WITH_OFFICIAL_SHA256_FOR_OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.10_7.tar.gz"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,19 +11,23 @@ FROM tomcat:11.0.18-jdk21 AS fnl_base_image
 # Upgrade OS packages, install deps, and update Java to Temurin 21.0.10.
 ARG TEMURIN_DIR="jdk-21.0.10+7"
 ARG TEMURIN_BUILD="21.0.10_7"
+# SHA256 checksums for the Temurin JDK tarballs (replace with the official published values)
+ARG TEMURIN_SHA256_AMD64="REPLACE_WITH_OFFICIAL_SHA256_FOR_OpenJDK21U-jdk_x64_linux_hotspot_21.0.10_7.tar.gz"
+ARG TEMURIN_SHA256_ARM64="REPLACE_WITH_OFFICIAL_SHA256_FOR_OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.10_7.tar.gz"
 RUN set -eux; \
     apt-get update; \
     apt-get -y upgrade; \
     apt-get install -y --no-install-recommends ca-certificates curl tar unzip; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-      amd64) temurin_arch="x64" ;; \
-      arm64) temurin_arch="aarch64" ;; \
+      amd64) temurin_arch="x64"; temurin_sha256="$TEMURIN_SHA256_AMD64" ;; \
+      arm64) temurin_arch="aarch64"; temurin_sha256="$TEMURIN_SHA256_ARM64" ;; \
       *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
     url="https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.10%2B7/OpenJDK21U-jdk_${temurin_arch}_linux_hotspot_${TEMURIN_BUILD}.tar.gz"; \
     mkdir -p /opt/java; \
     curl -fsSL "$url" -o /tmp/temurin.tgz; \
+    echo "$temurin_sha256  /tmp/temurin.tgz" | sha256sum -c -; \
     tar -xzf /tmp/temurin.tgz -C /opt/java; \
     rm /tmp/temurin.tgz; \
     rm -rf /opt/java/openjdk; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,18 @@ RUN mvn package -DskipTests
 # Production stage
 FROM tomcat:11.0.18-jdk21 AS fnl_base_image
 
-RUN apt-get update && apt-get -y upgrade
+# Upgrade OS packages, install deps, and update Java to 21.0.10.
+RUN set -eux; \
+    apt-get update; \
+    apt-get -y upgrade; \
+    apt-get install -y --no-install-recommends openjdk-21-jdk unzip; \
+    ln -sfn "/usr/lib/jvm/java-21-openjdk-$(dpkg --print-architecture)" /usr/lib/jvm/java-21-openjdk; \
+    /usr/lib/jvm/java-21-openjdk/bin/java -version; \
+    /usr/lib/jvm/java-21-openjdk/bin/java -version 2>&1 | grep -Fq '21.0.10'; \
+    rm -rf /var/lib/apt/lists/*
 
-# install dependencies and clean up unused files
-RUN apt-get update && apt-get install unzip
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN rm -rf /usr/local/tomcat/webapps.dist
 RUN rm -rf /usr/local/tomcat/webapps/ROOT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,6 @@ RUN set -eux; \
     java -version; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN rm -rf /usr/local/tomcat/webapps.dist
 RUN rm -rf /usr/local/tomcat/webapps/ROOT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,30 @@ RUN mvn package -DskipTests
 # Production stage
 FROM tomcat:11.0.18-jdk21 AS fnl_base_image
 
-# Upgrade OS packages, install deps, and update Java to 21.0.10.
+# Upgrade OS packages, install deps, and update Java to Temurin 21.0.10.
+ARG TEMURIN_DIR="jdk-21.0.10+7"
+ARG TEMURIN_BUILD="21.0.10_7"
 RUN set -eux; \
     apt-get update; \
     apt-get -y upgrade; \
-    apt-get install -y --no-install-recommends openjdk-21-jdk unzip; \
-    ln -sfn "/usr/lib/jvm/java-21-openjdk-$(dpkg --print-architecture)" /usr/lib/jvm/java-21-openjdk; \
-    /usr/lib/jvm/java-21-openjdk/bin/java -version; \
-    /usr/lib/jvm/java-21-openjdk/bin/java -version 2>&1 | grep -Fq '21.0.10'; \
+    apt-get install -y --no-install-recommends ca-certificates curl tar unzip; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) temurin_arch="x64" ;; \
+      arm64) temurin_arch="aarch64" ;; \
+      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    url="https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.10%2B7/OpenJDK21U-jdk_${temurin_arch}_linux_hotspot_${TEMURIN_BUILD}.tar.gz"; \
+    mkdir -p /opt/java; \
+    curl -fsSL "$url" -o /tmp/temurin.tgz; \
+    tar -xzf /tmp/temurin.tgz -C /opt/java; \
+    rm /tmp/temurin.tgz; \
+    rm -rf /opt/java/openjdk; \
+    mv "/opt/java/${TEMURIN_DIR}" /opt/java/openjdk; \
+    java -version; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN rm -rf /usr/local/tomcat/webapps.dist
 RUN rm -rf /usr/local/tomcat/webapps/ROOT

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>11.0.13</version>
+            <version>11.0.18</version>
         </dependency>
         <!-- JUnit -->
         <dependency>


### PR DESCRIPTION
### Overview

Updates base image and Java

### Change Details (Specifics)

Updated Tomcat base image from 11.0.13 to 11.0.18. Added commands to Dockerfile to update Java from the base image's 21.0.9 to 21.0.10.

### Related Ticket(s)

https://tracker.nci.nih.gov/browse/C3DC-2135
https://tracker.nci.nih.gov/browse/C3DC-2128
