### PR TITLE
fix(security): upgrade log4j and tomcat embed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ mvnw
 mvnw.cmd
 .github/
 .git/
+twistcli

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,32 +6,12 @@ COPY . .
 RUN mvn package -DskipTests
 
 # Production stage
-FROM tomcat:11.0.22-jdk21-temurin-jammy AS fnl_base_image
+FROM tomcat:11.0.22-jdk21-temurin-noble AS fnl_base_image
 
-# Upgrade OS packages, install deps, and update Java to Temurin 21.0.10.
-ARG TEMURIN_DIR=jdk-21.0.10+7
-ARG TEMURIN_BUILD=21.0.10_7
-# Official SHA256 checksums for the Temurin JDK tarballs for the above TEMURIN_DIR/TEMURIN_BUILD.
-ARG TEMURIN_SHA256_AMD64="ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4"
-ARG TEMURIN_SHA256_ARM64="357fee29fb0d5c079f6730db98b28942df13a6eed426f6c61cd4ad703ab27b9a"
 RUN set -eux; \
     apt-get update; \
     apt-get -y upgrade; \
-    apt-get install -y --no-install-recommends ca-certificates curl tar unzip; \
-    arch="$(dpkg --print-architecture)"; \
-    case "$arch" in \
-      amd64) temurin_arch="x64"; temurin_sha256="$TEMURIN_SHA256_AMD64" ;; \
-      arm64) temurin_arch="aarch64"; temurin_sha256="$TEMURIN_SHA256_ARM64" ;; \
-      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
-    esac; \
-    url="https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.10%2B7/OpenJDK21U-jdk_${temurin_arch}_linux_hotspot_${TEMURIN_BUILD}.tar.gz"; \
-    mkdir -p /opt/java; \
-    curl -fsSL "$url" -o /tmp/temurin.tgz; \
-    echo "$temurin_sha256  /tmp/temurin.tgz" | sha256sum -c -; \
-    tar -xzf /tmp/temurin.tgz -C /opt/java; \
-    rm /tmp/temurin.tgz; \
-    rm -rf /opt/java/openjdk; \
-    mv "/opt/java/${TEMURIN_DIR}" /opt/java/openjdk; \
+    apt-get install -y --no-install-recommends ca-certificates; \
     java -version; \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,31 @@ FROM tomcat:11.0.22-jdk21-temurin-noble AS fnl_base_image
 
 RUN set -eux; \
     apt-get update; \
-    apt-get -y upgrade; \
+    apt-get -y full-upgrade; \
+    apt-get install -y --no-install-recommends --only-upgrade \
+        libc6 \
+        libc-bin \
+        locales \
+        util-linux \
+        util-linux-extra \
+        mount \
+        bsdutils \
+        libblkid1 \
+        libmount1 \
+        libsmartcols1 \
+        libuuid1; \
     apt-get install -y --no-install-recommends ca-certificates; \
+    # Mitigate util-linux mount TOCTOU CVE path by disabling SUID binaries not needed in containers.
+    if [ -f /usr/bin/mount ]; then chmod u-s /usr/bin/mount; fi; \
+    if [ -f /usr/bin/umount ]; then chmod u-s /usr/bin/umount; fi; \
+    # Remove toolchain packages if inherited from base layers; not needed at runtime.
+    if dpkg-query -W -f='${Status}' binutils 2>/dev/null | grep -q "ok installed"; then \
+        apt-get purge -y --auto-remove \
+            binutils \
+            binutils-aarch64-linux-gnu \
+            binutils-common \
+            libbinutils; \
+    fi; \
     java -version; \
     rm -rf /var/lib/apt/lists/*
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.25.3</version>
+            <version>2.25.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.3</version>
+            <version>2.25.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
@@ -207,7 +207,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>11.0.21</version>
+            <version>11.0.22</version>
         </dependency>
         <!-- JUnit -->
         <dependency>


### PR DESCRIPTION
This pull request updates both the Docker build process and several dependencies to improve security and maintain compatibility. The most important changes are grouped below:

**Dependency Updates:**

* Upgraded `log4j-api` and `log4j-core` dependencies from version `2.25.3` to `2.25.4` in `pom.xml` for the latest security and bug fixes.
* Updated `tomcat-embed-core` dependency from version `11.0.21` to `11.0.22` in `pom.xml` for improved compatibility and security.

**Dockerfile and Base Image Improvements:**

* Switched the Tomcat base image in `Dockerfile` from `temurin-jammy` to `temurin-noble` to use a newer Ubuntu release.
* Simplified and hardened the Docker build process by removing manual JDK installation logic (now relies on the base image JDK), performing a full OS upgrade, updating critical system libraries, and mitigating CVE risks by disabling SUID bits on certain binaries.
* Added logic to remove unnecessary toolchain packages (such as `binutils`) from the final image to reduce attack surface and image size.This pull request updates dependencies in the `pom.xml` file to address version upgrades for logging and server libraries. The main focus is on keeping the project up-to-date with the latest stable releases of critical dependencies.

Dependency upgrades:

* Upgraded `log4j-api` and `log4j-core` dependencies from version `2.25.3` to `2.25.4` to ensure the latest bug fixes and security patches are included. (`pom.xml`)
* Upgraded `tomcat-embed-core` dependency from version `11.0.21` to `11.0.22` to incorporate the latest improvements and fixes. (`pom.xml`)Upgrade vulnerable dependencies in pom.xml to patched versions.\n\n- log4j-api: 2.25.3 -> 2.25.4\n- log4j-core: 2.25.3 -> 2.25.4\n- tomcat-embed-core: 11.0.21 -> 11.0.22\n\nAddresses targeted SCA CVEs identified during remediation.
